### PR TITLE
Remove possibility to remove or add elements to an existing Lattice object

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -201,18 +201,11 @@ As a nested structure is not always convenient to work with, there are three oth
 Adding and Removing Objects
 ---------------------------
 
-The :attr:`~Lattice.tree` of objects can also be altered after the lattice was created. Use :meth:`Lattice.add` to add objects to the tree::
-
-   >>> dba_cell.add(drift)
-   >>> dba_cell.tree
-   [Drift, Dipole, Drift, Quadrupole, Drift, Dipole, Drift, Drift]
-
-Remove objects from the :attr:`~Lattice.tree` with :meth:`Lattice.remove`::
-
-   >>> dba_cell.remove(-1)
-   >>> dba_cell.tree
-   [Drift, Dipole, Drift, Quadrupole, Drift, Dipole, Drift]
-
+As adding and removing objects from the :attr:`~Lattice.tree` significantly increased the
+code complextetiy, it was decided that :attr:`~Lattice.tree` cannont be altered after the
+:class:`Lattice` was created. If you needed to add/remove an object just create a new
+:class:`Lattice` object or initially add an :class:`Element` with length zero, which can
+be altered when needed.
 
 Load and Save Lattice Files
 ---------------------------

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -4,12 +4,13 @@ import pytest
 
 def test_length_changed():
     drift = ap.Drift("Drift", length=1)
-    cell_1 = ap.Lattice("Lattice", [drift, drift])
-    cell_2 = ap.Lattice("Lattice", [cell_1, cell_1])
-    cell_3 = ap.Lattice("Lattice", [cell_2, cell_2])
+    cell_1 = ap.Lattice("Cell1", [drift, drift])
+    cell_2 = ap.Lattice("Cell2", [cell_1, cell_1])
+    cell_3 = ap.Lattice("Cell3", [cell_2, cell_2])
     initial_length = cell_3.length
     for i in range(2, 10):
         drift.length += 1
+        print("TEST:", drift.length, cell_3.length)
         assert i * initial_length == cell_3.length
 
 
@@ -18,43 +19,10 @@ def test_unique_names():
     drift_2 = ap.Drift("Drift", length=2)
 
     with pytest.raises(ap.AmbiguousNameError):
-        ap.Lattice("Lattice", [drift_1, drift_2]).update_tree_properties()
+        ap.Lattice("Lattice", [drift_1, drift_2])
 
-    cell_1 = ap.Lattice("Lattice")
-    cell_2 = ap.Lattice("Lattice")
+    cell_1 = ap.Lattice("Lattice", [])
+    cell_2 = ap.Lattice("Lattice", [])
 
     with pytest.raises(ap.AmbiguousNameError):
-        ap.Lattice("Lattice", [cell_1, cell_2]).update_tree_properties()
-
-
-def test_add_remove_objects():
-    e1 = ap.Element("e1", length=1)
-    e2 = ap.Element("e2", length=1)
-    cell = ap.Lattice("Sub-Lattice")
-    cell_2 = ap.Lattice("Lattice", [cell] * 2)
-
-    assert 0 == cell_2.length
-
-    cell.add(e1)
-    assert [e1] == cell.tree
-    assert 2 == cell_2.length
-
-    cell.add(e2, pos=-1)
-    assert [e2, e1] == cell.tree
-    assert 4 == cell_2.length
-
-    cell.add([e1, e2], pos=0)  # add list
-    assert [e1, e2, e2, e1] == cell.tree
-    assert 8 == cell_2.length
-
-    cell.add((e1,), pos=-2)  # add tuple
-    assert [e1, e2, e1, e2, e1] == cell.tree
-    assert 10 == cell_2.length
-
-    cell.remove(2)
-    assert [e1, e2, e2, e1] == cell.tree
-    assert 8 == cell_2.length
-
-    cell.remove(-3, 2)
-    assert [e1, e1] == cell.tree
-    assert 4 == cell_2.length
+        ap.Lattice("Lattice", [cell_1, cell_2])


### PR DESCRIPTION
Currently it is possible to add/remove elements to/from an existing `Lattice` object. As this increases the code complexity significantly (this PR will remove 110 lines of code) it was decided to get rid of this mechanism. 

No functionality is lost because it is always possible to create a new `Lattice` instead of changing an existing one. Also this should not be slower because, when the `tree` of an `Lattice` object changes almost all of its depended attributes will change. In this case it is really hard to be smart about what can be cached. For example, when a new `Element` is within inserted within a `Lattice` this will change the position/index of all following elements, which then again changes the size of the `orbit_position` or `Twiss.beta_x` arrays, which have then to be reallocated. If a Lattice gets changed, everything has to be recalculated anyways. So why try to be smart and make it unnecessary complex.

@PaulGoslawski I decided to remove the `add/remove` functionality