### PR TITLE
fix nested sub-sub-lattices not in top level lattice

### DIFF
--- a/apace/plot.py
+++ b/apace/plot.py
@@ -358,7 +358,11 @@ class TwissPlot:
 
         handles, labels = self.fig.axes[0].get_legend_handles_labels()
         self.fig.legend(handles, labels, loc="upper left", ncol=10, frameon=False)
-        self.fig.suptitle(twiss.lattice.name, ha="right", x=0.98)
+        title = self.lattice.name
+        if self.lattice.info != "":
+            title += f"({self.lattice.info})"
+
+        self.fig.suptitle(title, ha="right", x=0.98)
         self.fig.tight_layout()
 
     def update(self):

--- a/data/lattices/nested_lattice.json
+++ b/data/lattices/nested_lattice.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0",
+    "title": "Nested Lattice",
+    "root": "MAIN",
+    "elements": {
+        "D1": [
+            "Drift",
+            {
+                "length": 1.0
+            }
+        ],
+        "D2": [
+            "Drift",
+            {
+                "length": 2.0
+            }
+        ]
+    },
+    "lattices": {
+        "SUB1": [
+            "D1",
+            "D2"
+        ],
+        "SUB2": [
+            "D1",
+            "SUB1",
+            "D2"
+        ],
+        "SUB3": [
+            "D1",
+            "SUB2",
+            "D2"
+        ],
+        "MAIN": [
+            "D1",
+            "SUB3",
+            "D2"
+        ]
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import apace as ap
 BASE_PATH = Path(__file__).resolve().parent
 LATTICE_PATH = BASE_PATH / "../data/lattices"
 FODO_CELL_JSON = json.loads((LATTICE_PATH / "fodo_cell.json").read_text())
+NESTED_LATTICE = json.loads((LATTICE_PATH / "nested_lattice.json").read_text())
 
 
 @pytest.fixture
@@ -29,3 +30,8 @@ def fodo_cell():
 @pytest.fixture
 def fodo_ring(fodo_cell):
     return ap.Lattice("fodo-ring", 8 * [fodo_cell])
+
+
+@pytest.fixture
+def nested_lattice():
+    return ap.Lattice.from_dict(NESTED_LATTICE)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -33,8 +33,9 @@ def test_attributes(fodo_cell):
     assert 48 == fodo_ring.length
 
 
-def test_serialize_lattice(fodo_ring):
-    fodo_reload = ap.Lattice.from_dict(fodo_ring.as_dict())
-    assert fodo_ring.length == fodo_reload.length
-    assert len(fodo_ring.elements) == len(fodo_reload.elements)
-    assert len(fodo_ring.sub_lattices) == len(fodo_reload.sub_lattices)
+def test_serialize_lattice(fodo_cell, nested_lattice):
+    for lattice in fodo_cell, nested_lattice:
+        lattice_reload = ap.Lattice.from_dict(lattice.as_dict())
+        assert lattice.length == lattice_reload.length
+        assert len(lattice.elements) == len(lattice_reload.elements)
+        assert len(lattice.sub_lattices) == len(lattice_reload.sub_lattices)


### PR DESCRIPTION
Sub sub lattices were not added to the top level `sub_lattice` attribute because of 

```python
yield from Lattice.traverse_tree(obj)
```

instead of

```python
yield from Lattice.traverse_tree(obj.tree)
```

This also did not throw an error because implementing a `__getitem__` method made the `Lattice` class an `Iterable`. So it ONLY iterated over the elements, while leaving out the sub-lattices.
